### PR TITLE
test: add pop-up challenge test for candymapper.com

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,9 +1,9 @@
 name: Playwright Tests
 on:
   push:
-    branches: [ main, master ]
+    branches: main
   pull_request:
-    branches: [ main, master ]
+    branches: main
 jobs:
   test:
     timeout-minutes: 60

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -19,6 +19,8 @@ jobs:
         node-version: lts/*
     - name: Install dependencies
       run: npm ci
+    - name: Install missing dependencies for WebKit
+      run: sudo apt-get update && sudo apt-get install -y libwoff1
     - name: Get installed Playwright version
       id: playwright-version
       run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -19,8 +19,6 @@ jobs:
         node-version: lts/*
     - name: Install dependencies
       run: npm ci
-    - name: Install missing dependencies for WebKit
-      run: sudo apt-get update && sudo apt-get install -y libwoff1
     - name: Get installed Playwright version
       id: playwright-version
       run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
@@ -33,7 +31,6 @@ jobs:
         key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
     - name: Run Playwright tests
       run: npx playwright test --project=${{ matrix.browser }}
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,6 +8,10 @@ jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
@@ -29,10 +33,10 @@ jobs:
       run: npx playwright install --with-deps
       if: steps.playwright-cache.outputs.cache-hit != 'true'
     - name: Run Playwright tests
-      run: npx playwright test
+      run: npx playwright test --project=${{ matrix.browser }}
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:
-        name: playwright-report
+        name: playwright-report-${{ matrix.browser }}
         path: playwright-report/
         retention-days: 30

--- a/tests/CandyMapper/candymappercom.spec.ts
+++ b/tests/CandyMapper/candymappercom.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Testing CandyMapper.com Site', () => {
+  test('Pop-Up Challenge', async ({ page }) => { 
+    
+    await page.goto('http://www.candymapper.com');
+    
+    //This timeout is necessary for the page to load all the javascript to load
+    //the event handlers for the submit button
+    await page.waitForTimeout(7000);
+
+    //Close the layer and enter first and last name on the page form
+    await expect(page.locator('[data-aid="POPUP_MODAL"]')).toBeVisible();
+    await page.locator('#popup-widget307423-close-icon').click();
+    await page.locator('input[data-aid="First Name"]').fill('Test');
+    await page.locator('input[data-aid="Last Name"]').fill('Name');
+   
+    //Confirm an error message displays with email missing on submit
+    const submitBtn = page.getByRole('button', { name: /submit/i });
+    await submitBtn.click();
+    await expect(page.locator('[data-aid="CONTACT_EMAIL_ERR_REND"]')).toBeVisible();
+    await expect(page.getByText('Please enter a valid email address.')).toBeVisible();
+
+    //Successfully submit after email is entered
+    await page.locator('input[data-aid="CONTACT_FORM_EMAIL"]').fill('email@email.com');
+    await submitBtn.click();
+    await expect(page.locator('[data-aid="CONTACT_FORM_SUBMIT_SUCCESS_MESSAGE"]')).toBeVisible();
+    await expect(page.getByText('48 Years')).toBeVisible();
+  });
+});


### PR DESCRIPTION
### Overview

Follow the automation steps A thru C of the Pop-Up Challenge at CandyMapper site. 

<img width="517" height="491" alt="candymapper" src="https://github.com/user-attachments/assets/b9e39bd4-5f25-4a5f-b809-722a57697523" />

### Changes

- Added a spec file to test the Pop-Up challenge on the CandyMapper site as shown above.
- Updated the YML file to allow parallel runs of the 3 Playwright browsers: chromium, firefox, webkit