### PR TITLE
fix: resolve native browser validation conflicts on rate and term fields

### DIFF
--- a/app/refinance-calculator/app.js
+++ b/app/refinance-calculator/app.js
@@ -58,6 +58,9 @@ function validateForm() {
   } else if (parseInt(termInput.value, 10) < 1) {
     termError.textContent = 'Remaining Term must be at least 1 month.';
     isValid = false;
+  } else if (!Number.isInteger(parseFloat(termInput.value))) {
+    termError.textContent = 'Remaining Term must be a whole number.';
+    isValid = false;
   }
 
   return isValid;

--- a/app/refinance-calculator/index.html
+++ b/app/refinance-calculator/index.html
@@ -29,12 +29,12 @@
         </div>
         <div class="form-group">
           <label for="rate">Current Interest Rate (%)</label>
-          <input type="number" id="rate" name="rate" placeholder="e.g. 6.5" step="0.1" />
+          <input type="number" id="rate" name="rate" placeholder="e.g. 6.5" step="any" />
           <span class="field-error" id="rate-error" aria-live="polite"></span>
         </div>
         <div class="form-group">
           <label for="term">Remaining Term (months)</label>
-          <input type="number" id="term" name="term" placeholder="e.g. 48" />
+          <input type="number" id="term" name="term" placeholder="e.g. 48" step="any"/>
           <span class="field-error" id="term-error" aria-live="polite"></span>
         </div>
         <button type="submit" class="check-rates-btn">Check Rates</button>

--- a/tests/RefinanceCalculator/refinance-calculator.spec.ts
+++ b/tests/RefinanceCalculator/refinance-calculator.spec.ts
@@ -51,6 +51,11 @@ test.describe('Auto Loan Refinance Calculator', () => {
 
     await expect(page.getByText('Current Interest Rate must be at least 0.1%.')).toBeVisible();
     await expect(page.getByRole('listitem')).toHaveCount(0);
+
+    await fillAndSubmitLoanForm(page, '18000', '0.05', '48');
+
+    await expect(page.getByText('Current Interest Rate must be at least 0.1%.')).toBeVisible();
+    await expect(page.getByRole('listitem')).toHaveCount(0);
   });
 
   test('should show error when Remaining Term is blank', async ({ page }) => {
@@ -66,6 +71,13 @@ test.describe('Auto Loan Refinance Calculator', () => {
     await fillAndSubmitLoanForm(page, '18000', '6.5', '0');
 
     await expect(page.getByText('Remaining Term must be at least 1 month.')).toBeVisible();
+    await expect(page.getByRole('listitem')).toHaveCount(0);
+  });
+
+  test('should show error when Remaining Term is a decimal and not a whole number', async ({ page }) => {
+    await fillAndSubmitLoanForm(page, '18000', '6.5', '12.5');
+
+    await expect(page.getByText('Remaining Term must be a whole number.')).toBeVisible();
     await expect(page.getByRole('listitem')).toHaveCount(0);
   });
 


### PR DESCRIPTION
## Overview
Fixes two validation bugs discovered by the AI agent. Both issues stemmed from conflicting browser native validation interfering with the app's custom JavaScript validation, resulting in inconsistent error messages or silent failures.

## Changes
- `app/refinance-calculator/index.html` — added `step="any"` to `#rate` and `#term` fields to suppress native browser validation and allow custom JS errors to display correctly
- `app/refinance-calculator/app.js` — added integer validation for `#term` field so decimal values (e.g. 12.7) now show a styled error message instead of silently returning no results
- `tests/RefinanceCalculator/refinance-calculator.spec.ts` — added regression tests covering rate values between 0 and 0.1, and decimal term values